### PR TITLE
feat: 모바일 웹 vh 단위 오동작 보완 기능 추가

### DIFF
--- a/packages/app/src/components/layout/Authorize.tsx
+++ b/packages/app/src/components/layout/Authorize.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Navigate, Outlet, useSearchParams } from 'react-router-dom';
+import { Navigate, Outlet } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { authState } from 'stores/auth';
 

--- a/packages/app/src/components/layout/Base.tsx
+++ b/packages/app/src/components/layout/Base.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
+
+import { useVh } from 'hooks';
 import { Outlet } from 'react-router-dom';
 
 function Base() {
+  useVh();
+
   return (
     <>
       <Outlet />

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useVh } from './useVh';

--- a/packages/app/src/hooks/useVh.ts
+++ b/packages/app/src/hooks/useVh.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const setVh = () => {
+  const vh = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${vh}px`);
+};
+
+function useVh() {
+  useEffect(() => {
+    setVh();
+    window.addEventListener('resive', setVh);
+
+    return () => {
+      window.removeEventListener('resize', setVh);
+    };
+  }, []);
+}
+
+export default useVh;

--- a/packages/app/src/pages/Login/style.ts
+++ b/packages/app/src/pages/Login/style.ts
@@ -7,7 +7,7 @@ const login: CSSObject = {
   alignItems: 'center',
   gap: 8,
   padding: 24,
-  height: '100vh',
+  height: 'calc(var(--vh, 1vh) * 100)',
 };
 
 export { login };

--- a/packages/app/src/pages/Splash/style.ts
+++ b/packages/app/src/pages/Splash/style.ts
@@ -2,7 +2,7 @@ import { CSSObject, keyframes } from '@emotion/react';
 
 const wrap: CSSObject = {
   width: '100%',
-  height: '100vh',
+  height: 'calc(var(--vh, 1vh) * 100)',
   backgroundColor: '#fff',
 
   display: 'flex',


### PR DESCRIPTION
## *관련 작업 티켓

- https://dobugs.atlassian.net/browse/YOL-82

## *작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- css에서 전체 스크린 높이의 1/100 사이즈 단위인 vh가 실제로 뷰포트의 1/100가 아님
    - 모바일 웹 브라우저에서 상단 주소창 및 하단 네비게이션바 등이 포함되서 오동작
    
 - window.innerHeight의 1/100로 잡아서 css 깨지는 오류 수정

## 관련 Docs (optional)

- 작업을 진행하면서 참고한 문서 혹은 자료를 공유합니다.
- 리뷰어 혹은 PR을 보는 동료들과 새롭게 알게된 지식을 공유하기 위한 것이 목적입니다.
- 또한, 리뷰에 도움을 주는 것도 목적입니다.

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
